### PR TITLE
feat: precompiled binaries

### DIFF
--- a/.github/workflows/precompiled_binaries.yml
+++ b/.github/workflows/precompiled_binaries.yml
@@ -1,0 +1,44 @@
+on:
+  push:
+    branches: [ master ]
+
+name: Precompile Binaries
+jobs:
+  Precompile:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macOS-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Install GTK
+        if: (matrix.os == 'ubuntu-latest')
+        run: sudo apt-get update && sudo apt-get install libgtk-3-dev
+      - name: Set up Android SDK
+        if: (matrix.os == 'ubuntu-20.04')
+        uses: android-actions/setup-android@v2 
+
+      - name: Install Specific NDK
+        if: (matrix.os == 'ubuntu-20.04')
+        run: sdkmanager --install "ndk;24.0.8215888" 
+      - name: Precompile
+        if: (matrix.os == 'macOS-latest') || (matrix.os == 'windows-latest')
+        run: dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=rust-nostr/nostr-sdk-flutter
+        working-directory: cargokit/build_tool
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
+
+      - name: Precompile (with Android)
+        if: (matrix.os == 'ubuntu-latest')
+        run: dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=rust-nostr/nostr-sdk-flutter --android-sdk-location=/usr/local/lib/android/sdk --android-ndk-version=24.0.8215888 --android-min-sdk-version=23
+        working-directory: cargokit/build_tool
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }

--- a/cargokit/build_tool/lib/src/options.dart
+++ b/cargokit/build_tool/lib/src/options.dart
@@ -301,7 +301,10 @@ class CargokitUserOptions {
       }
       userProjectDir = userProjectDir.parent;
     }
-    return CargokitUserOptions._();
+    return CargokitUserOptions(
+      usePrecompiledBinaries: true,
+      verboseLogging: false,
+    );
   }
 
   final bool usePrecompiledBinaries;

--- a/rust/cargokit.yml
+++ b/rust/cargokit.yml
@@ -1,0 +1,13 @@
+cargo:
+  debug:
+    toolchain: stable
+  release:
+    toolchain: nightly
+    extra_flags:
+      - -Z
+      - build-std=panic_abort,std
+precompiled_binaries:
+  # Uri prefix used when downloading precompiled binaries.
+  url_prefix: https://github.com/rust-nostr/nostr-sdk-flutter/releases/download/precompiled_
+  # Public key for verifying downloaded precompiled binaries.
+  public_key: <RELEASE_PUBLIC_KEY>


### PR DESCRIPTION
Precompiled binaries speed up the building process of the flutter apps that consume your bindings avoiding developers the need of the rust toolchain to compile your package by downloading precompiled binaries. 

- [x] precompiled binaries CI
- [x] add cargokit configuration
- [ ] @yukibtc   generate a github token to push the binaries to the release and add it to `secrets.RELEASE_GITHUB_TOKEN` of the repositories
- [ ] @yukibtc  generate a private key  to sign the binaries and add it to `secrets.RELEASE_PRIVATE_KEY` of the repositories
- [ ] @yukibtc  replace `<RELEASE_PUBLIC_KEY>` in `rust/cargokit.yml`